### PR TITLE
alternate whitespace handling

### DIFF
--- a/lib/saxy/element.rb
+++ b/lib/saxy/element.rb
@@ -16,7 +16,8 @@ module Saxy
     end
 
     def append_value(string)
-      unless (string = string.strip).empty?
+      #unless (string = string.strip).empty?
+      unless string.empty?
         @value ||= ""
         @value << string
       end

--- a/spec/fixtures/webstore.xml
+++ b/spec/fixtures/webstore.xml
@@ -15,7 +15,7 @@
     <product>
       <uid>YD26NT</uid>
       <name>Kindle Touch</name>
-      <description>Simple-to-use touchscreen with built-in WIFI.</description>
+      <description>Simple-to-use touchscreen with built-in WIFI &amp; WhisperSync.</description>
       <price>$79</price>
       <images count="2">
         <thumb>http://amazon.com/kindle_touch_thumb.jpg</thumb>

--- a/spec/saxy_spec.rb
+++ b/spec/saxy_spec.rb
@@ -18,7 +18,7 @@ describe Saxy do
 
     products[1].uid.should == "YD26NT"
     products[1].name.should == "Kindle Touch"
-    products[1].description.should == "Simple-to-use touchscreen with built-in WIFI."
+    products[1].description.should == "Simple-to-use touchscreen with built-in WIFI & WhisperSync."
     products[1].price.should == "$79"
     products[1].images.thumb.should == "http://amazon.com/kindle_touch_thumb.jpg"
     products[1].images.large.should == "http://amazon.com/kindle_touch.jpg"


### PR DESCRIPTION
I noticed that saxy was stripping whitespace around HTML entities like &amp;amp;.  This branch fixes that, but breaks the ./spec/saxy/element_spec.rb:14 test.  I don't quite understand the use case around that test, but can try to get them both working together if that's possible.
