### PR TITLE
Check IO object behavior when given for parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Memory-efficient XML parser. Finds object definitions in XML and translates them into Ruby objects.
 
-It uses SAX parser under the hood, which means that it doesn't load the whole XML file into memory. It goes once though it and yields objects along the way.
+It uses SAX parser under the hood, which means that it doesn't load the whole XML file into memory. It goes once through it and yields objects along the way.
 
 ## Installation
 
@@ -44,10 +44,12 @@ Assume the XML file:
       </products>
     </webstore>
 
-You instantiate the parser by passing path to XML file and object-identyfing tag name as its arguments.
+You instantiate the parser by passing path to XML file or an IO-like object and object-identyfing tag name as its arguments.
 
 The following will parse the XML, find product definitions (inside `<product>` and `</product>` tags), build `OpenStruct`s and yield them inside the block.
 Tag attributes become object attributes and attributes' name are underscored.
+
+Usage with a file path:
 
     Saxy.parse("filename.xml", "product").each do |product|
       puts product.name
@@ -62,6 +64,16 @@ Tag attributes become object attributes and attributes' name are underscored.
       Kindle Touch - Simple-to-use touchscreen with built-in WIFI.
       http://amazon.com/kindle_touch_thumb.jpg
       120x90
+
+Usage with an IO-like object `ARGF`:
+
+    # > cat filename.xml | ruby this_script.rb
+    Saxy.parse(ARGF, "product").each do |product|
+      puts product.name
+    end
+
+    # =>
+      Kindle - The world's best-selling e-reader.
 
 Saxy supports Enumerable, so you can use its goodies to your comfort without building intermediate arrays:
 

--- a/lib/saxy/parser.rb
+++ b/lib/saxy/parser.rb
@@ -16,8 +16,8 @@ module Saxy
     # Will yield objects inside the callback after they're built
     attr_reader :callback
 
-    def initialize(xml_file, object_tag)
-      @xml_file, @object_tag = xml_file, object_tag
+    def initialize(object, object_tag)
+      @object, @object_tag = object, object_tag
       @tags, @elements = [], []
     end
 
@@ -63,18 +63,16 @@ module Saxy
     end
 
     def each(&blk)
-      if blk
-        @callback = blk
+      return to_enum unless blk
 
-        parser = Nokogiri::XML::SAX::Parser.new(self)
+      @callback = blk
 
-        if @xml_file.is_a?(IO)
-          parser.parse_io(@xml_file)
-        else
-          parser.parse_file(@xml_file)
-        end
+      parser = Nokogiri::XML::SAX::Parser.new(self)
+
+      if @object.respond_to?(:read) && @object.respond_to?(:close)
+        parser.parse_io(@object)
       else
-        to_enum
+        parser.parse_file(@object)
       end
     end
   end

--- a/spec/fixtures/io_like.rb
+++ b/spec/fixtures/io_like.rb
@@ -1,0 +1,9 @@
+class IOLike
+  extend Forwardable
+
+  def_delegators :@io, :read, :close
+
+  def initialize(io)
+    @io = io
+  end
+end

--- a/spec/saxy/parser_spec.rb
+++ b/spec/saxy/parser_spec.rb
@@ -4,16 +4,22 @@ describe Saxy::Parser do
   include FixturesHelper
 
   let(:parser) { Saxy::Parser.new(fixture_file("webstore.xml"), "product") }
+  let(:file_io) { File.new(fixture_file("webstore.xml")) }
+  let(:io_like) { IOLike.new(file_io) }
 
-  it "should accept string filename as xml_file" do
+  it "should accept string filename for parsing" do
     xml_file = fixture_file("webstore.xml")
     parser = Saxy::Parser.new(xml_file, "product")
     parser.each.to_a.size.should == 2
   end
 
-  it "should accept IO as xml_file" do
-    xml_file = File.new(fixture_file("webstore.xml"))
-    parser = Saxy::Parser.new(xml_file, "product")
+  it "should accept IO for parsing" do
+    parser = Saxy::Parser.new(file_io, "product")
+    parser.each.to_a.size.should == 2
+  end
+
+  it "should accept an IO-like for parsing" do
+    parser = Saxy::Parser.new(io_like, "product")
     parser.each.to_a.size.should == 2
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,5 +3,6 @@ require 'bundler/setup'
 require 'saxy'
 
 require 'fixtures_helper'
+require File.join(File.dirname(__FILE__), 'fixtures', 'io_like')
 
 RUBY_1_8 = (RUBY_VERSION =~ /^1\.8/)


### PR DESCRIPTION
Change `#each` to check `IO` _behavior_ of given object with same methods as Nokogiri
(https://github.com/sparklemotion/nokogiri/blob/master/lib/nokogiri/xml/sax/parser.rb#L80)
instead of checking the IO ancestor.

This will allow `ARGF`, `SFTP` read objects, and other objects that implement the IO interface but don't share the ancestor class to be passed in for parsing correctly.

This does not affect the filename argument behavior and falling back to parse_file if the object isn't IO-like.

I couldn't think of a creative way to pass in `ARGF` for testing without hanging on `read`, so I added a simpler test case than emulating an IO-like interface.
