### PR TITLE
Preserve spacing around &amp;

### DIFF
--- a/lib/saxy/element.rb
+++ b/lib/saxy/element.rb
@@ -15,6 +15,7 @@ module Saxy
 
     def append_value(string)
       unless (string = string.strip).empty?
+        string = string == '&' ? ' & ' : string
         @value ||= ""
         @value << string
       end

--- a/spec/saxy/element_spec.rb
+++ b/spec/saxy/element_spec.rb
@@ -14,6 +14,11 @@ describe Saxy::Element do
     expect(element.value).to eq("foobar")
   end
 
+  it "should preserve spacing around :&amp;" do
+    element.append_value('&')
+    expect(element.value).to eq(' & ')
+  end
+
   it "should dump as string when no attributes are set" do
     expect(element).to receive(:value).and_return("foo")
     expect(element.to_h).to eq("foo")


### PR DESCRIPTION
When parsing strings like ‘This &:amp; That’, preserve the spacing around the ‘&’.

Currently 'This &amp; That' parses to 'This&That'. 